### PR TITLE
Add logoimage and title for excel eport file

### DIFF
--- a/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
+++ b/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
@@ -154,7 +154,6 @@ class ExcelBuilder extends BuilderSupport {
         				log.debug("Creating label cell")
         				value = new Label(attributes?.column, attributes?.row, attributes?.value?.toString())
         			}
-
     				if(attributes?.format && formats.containsKey(attributes?.format)){
     					value.setCellFormat(formats[attributes.format])
     				}
@@ -213,6 +212,9 @@ class ExcelBuilder extends BuilderSupport {
         	    			
         	    	WritableFont font = new WritableFont(attributes.name, attributes["size"], attributes.bold, attributes.italic, attributes.underline);
         	    	WritableCellFormat cellFormat = new WritableCellFormat(font);
+        	    	if(attributes.alignment){
+                        cellFormat.setAlignment(attributes.alignment);
+        	    	}
         	    	formats.put(format, cellFormat)	
     			}
     			catch(Exception e){

--- a/src/groovy/de/andreasschmitt/export/exporter/DefaultExcelExporter.groovy
+++ b/src/groovy/de/andreasschmitt/export/exporter/DefaultExcelExporter.groovy
@@ -1,6 +1,7 @@
 package de.andreasschmitt.export.exporter
 
 import de.andreasschmitt.export.builder.ExcelBuilder
+import jxl.write.WritableImage
 
 /**
  * @author Andreas Schmitt
@@ -26,7 +27,53 @@ class DefaultExcelExporter extends AbstractExporter {
 							font(name: "arial", bold: true)
 						}
 						
-						int rowIndex = 0
+						
+                        int rowIndex = 0
+                        //Create image and add title
+                        if(data[0].image){
+                            // add Title format
+                            if(data[0].titleformat){
+                                def titleformat=data[0].titleformat
+                                format(name: "title"){
+                                    font( name: titleformat.fontfamily
+                                        , bold: titleformat.bold
+                                        , size:titleformat["size"]
+                                        , alignment:jxl.write.Alignment."$titleformat.alignment")
+                                }
+                            }
+                            
+                            sheet.addImage(
+                                new WritableImage(data[0].beginColumn
+                                                , data[0].beginRow
+                                                , data[0].crossColumn 
+                                                , data[0].crossRow
+                                                , data[0].image)
+                            )
+                            sheet.setRowView(data[0].beginRow, data[0].height)    //height
+                            sheet.setColumnView(data[0].beginColumn, data[0].width)  //width
+                            
+                            sheet.mergeCells( data[0].mergeColumn
+                                            , data[0].mergeRow
+                                            , data[0].mergeToColumn
+                                            , data[0].mergeToRow)
+                            // add Title
+                            if(data[0].title){
+                                sheet.mergeCells( data[0].mergeColumn
+                                                , data[0].mergeRow+1
+                                                , data[0].mergeToColumn
+                                                , data[0].mergeToRow)
+                                cell( row: data[0].beginRow+1
+                                    , column: data[0].beginColumn
+                                    , value: data[0].title
+                                    , format: "title")
+                                rowIndex =  1                                
+                            }
+                            if(data[0].beginRow==0){
+                                rowIndex +=1
+                            }
+                            
+                            data.remove(0)
+                        }
 						
 						//Create header
 						if(isHeaderEnabled){
@@ -34,10 +81,8 @@ class DefaultExcelExporter extends AbstractExporter {
 								String value = getLabel(field)
 								cell(row: rowIndex, column: index, value: value, format: "header")	
 							}
-							
-							rowIndex = 1
+							rowIndex += 1
 						}
-						
 						//Rows
 						data.eachWithIndex { object, k ->
 							fields.eachWithIndex { field, i ->


### PR DESCRIPTION
In my project, we need to export logoimage and table title into excel.
I change some code in DefaultExcelExporter and ExcelBuilder.
Using:

```
InputStream is = new FileInputStream(imagepath)
byte[] image = IOUtils.toByteArray(is)
def excelReport = []
excelReport << [
  image: image,
  width: 10,
  height: 2000,
  mergeColumn: 0,
  mergeRow: 0,
  mergeToColumn: fields.size() ? fields.size() - 1 : 0,
  mergeToRow: 0,
  beginColumn: 0,
  beginRow: 0,
  crossColumn: 6,
  crossRow: 1,
  title: "your table title",
  titleformat: [
    fontfamily: 'arial',
    bold: true,
    size: 20,
    alignment: 'CENTRE'
  ]
]
exportService.export( 'excel', response.outputStream, excelReport, fields, labels, formatters, parameters )
```

if excelReport do not has 'image',the export excel file is as before.
